### PR TITLE
break out the footer, header, and head info into _includes

### DIFF
--- a/_includes/components/footer.njk
+++ b/_includes/components/footer.njk
@@ -1,6 +1,141 @@
-<footer>
-  <small>
-    This project is maintained by <a href="https://www.danurbanowicz.com">Dan Urbanowicz</a>.
-    Check out the <a href="{{ pkg.repository.url }}">GitHub repo</a>.
-  </small>
-</footer>
+{% if locale === 'en' %}
+  <footer id="wb-info">
+    <div class="landscape">
+      <nav class="container wb-navcurr">
+        <h2 class="wb-inv">About government</h2>
+        <ul class="list-unstyled colcount-sm-2 colcount-md-3">
+          <li>
+            <a href="https://www.canada.ca/en/contact.html">Contact us</a>
+          </li>
+          <li>
+            <a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a>
+          </li>
+          <li>
+            <a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a>
+          </li>
+          <li>
+            <a href="https://www.canada.ca/en/news.html">News</a>
+          </li>
+          <li>
+            <a href="https://www.canada.ca/en/government/system/laws.html">Treaties, laws and regulations</a>
+          </li>
+          <li>
+            <a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide reporting</a>
+          </li>
+          <li>
+            <a href="https://pm.gc.ca/eng">Prime Minister</a>
+          </li>
+          <li>
+            <a href="https://www.canada.ca/en/government/system.html">How government works</a>
+          </li>
+          <li>
+            <a href="https://open.canada.ca/en/">Open government</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+    <div class="brand">
+      <div class="container">
+        <div class="row">
+          <nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
+            <h2 class="wb-inv">About this site</h2>
+            <ul>
+              <li>
+                <a href="https://www.canada.ca/en/social.html">Social media</a>
+              </li>
+              <li>
+                <a href="https://www.canada.ca/en/mobile.html">Mobile applications</a>
+              </li>
+              <li>
+                <a href="https://www1.canada.ca/en/newsite.html">About Canada.ca</a>
+              </li>
+              <li>
+                <a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a>
+              </li>
+              <li>
+                <a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a>
+              </li>
+            </ul>
+          </nav>
+          <div class="col-xs-6 visible-sm visible-xs tofpg">
+            <a href="#wb-cont">Top of Page
+              <span class="glyphicon glyphicon-chevron-up"></span></a>
+          </div>
+          <div class="col-xs-6 col-md-3 col-lg-2 text-right">
+            <img src="/static/assets/GCWeb/assets/wmms-blk.svg" alt="Symbol of the Government of Canada">
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+{% else %}
+  <footer id="wb-info">
+    <div class="landscape">
+      <nav class="container wb-navcurr">
+        <h2 class="wb-inv">Au sujet du gouvernement</h2>
+        <ul class="list-unstyled colcount-sm-2 colcount-md-3">
+          <li>
+            <a href="https://www.canada.ca/fr/contact.html">Contactez-nous</a>
+          </li>
+          <li>
+            <a href="https://www.canada.ca/fr/gouvernement/min.html">Ministères et organismes</a>
+          </li>
+          <li>
+            <a href="https://www.canada.ca/fr/gouvernement/fonctionpublique.html">Fonction publique et force militaire</a>
+          </li>
+          <li>
+            <a href="https://www.canada.ca/fr/nouvelles.html">Nouvelles</a>
+          </li>
+          <li>
+            <a href="https://www.canada.ca/fr/gouvernement/systeme/lois.html">Traités, lois et règlements</a>
+          </li>
+          <li>
+            <a href="https://www.canada.ca/fr/transparence/rapports.html">Rapports à l'échelle du gouvernement</a>
+          </li>
+          <li>
+            <a href="https://pm.gc.ca/fra">Premier ministre</a>
+          </li>
+          <li>
+            <a href="https://www.canada.ca/fr/gouvernement/systeme.html">Comment le gouvernement fonctionne</a>
+          </li>
+          <li>
+            <a href="https://ouvert.canada.ca/">Gouvernement ouvert</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+    <div class="brand">
+      <div class="container">
+        <div class="row">
+          <nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
+            <h2 class="wb-inv">À propos du site</h2>
+            <ul>
+              <li>
+                <a href="https://www.canada.ca/fr/sociaux.html">Médias sociaux</a>
+              </li>
+              <li>
+                <a href="https://www.canada.ca/fr/mobile.html">Applications mobiles</a>
+              </li>
+              <li>
+                <a href="https://www1.canada.ca/fr/nouveausite.html">À propos de Canada.ca</a>
+              </li>
+              <li>
+                <a href="https://www.canada.ca/fr/transparence/avis.html">Avis</a>
+              </li>
+              <li>
+                <a href="https://www.canada.ca/fr/transparence/confidentialite.html">Confidentialité</a>
+              </li>
+            </ul>
+          </nav>
+          <div class="col-xs-6 visible-sm visible-xs tofpg">
+            <a href="#wb-cont">Haut de la page
+              <span class="glyphicon glyphicon-chevron-up"></span></a>
+          </div>
+          <div class="col-xs-6 col-md-3 col-lg-2 text-right">
+            <img src="/static/assets/GCWeb/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada">
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+{% endif %}

--- a/_includes/components/head.njk
+++ b/_includes/components/head.njk
@@ -1,14 +1,16 @@
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{ title or renderData.title or metadata.title }}</title>
-  <script async src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-  {% set css %}
-    {% include "assets/css/inline.css" %}
-  {% endset %}
-  <style>{{ css | cssmin | safe }}</style>
-  {% set js %}
-    {% include "assets/js/inline.js" %}
-  {% endset %}
-  <script>{{ js | jsmin | safe }}</script>
+  <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+  <title>Canada.ca theme - Canada.ca
+  </title>
+  <meta content="width=device-width,initial-scale=1" name="viewport">
+  <meta name="description" content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
+  <!--[if gte IE 9 | !IE ]><!-->
+  <link href="/static/assets/GCWeb/assets/favicon.ico" rel="icon" type="image/x-icon">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
+  <link rel="stylesheet" href="/static/assets/GCWeb/css/theme.min.css">
+  <!--<![endif]-->
+  <!--[if lt IE 9]> <link href="/static/assets/GCWeb/assets/favicon.ico" rel="shortcut icon" /> <link rel="stylesheet" href="/static/assets/GCWeb/css/ie8-theme.min.css" /> <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.js"></script> <script src="/static/assets/wet-boew/js/ie8-wet-boew.min.js"></script> <![endif]-->
+  <!--[if lte IE 9]> <![endif]-->
+  <noscript><link rel="stylesheet" href="/static/assets/wet-boew/css/noscript.min.css"/></noscript>
 </head>

--- a/_includes/components/head.njk
+++ b/_includes/components/head.njk
@@ -13,4 +13,5 @@
   <!--[if lt IE 9]> <link href="/static/assets/GCWeb/assets/favicon.ico" rel="shortcut icon" /> <link rel="stylesheet" href="/static/assets/GCWeb/css/ie8-theme.min.css" /> <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.js"></script> <script src="/static/assets/wet-boew/js/ie8-wet-boew.min.js"></script> <![endif]-->
   <!--[if lte IE 9]> <![endif]-->
   <noscript><link rel="stylesheet" href="/static/assets/wet-boew/css/noscript.min.css"/></noscript>
+  <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>

--- a/_includes/components/header.njk
+++ b/_includes/components/header.njk
@@ -1,0 +1,192 @@
+{% if locale === 'en' %}
+  <nav>
+    <ul id="wb-tphp">
+      <li class="wb-slc">
+        <a class="wb-sl" href="#wb-cont">Skip to main content</a>
+      </li>
+      <li class="wb-slc">
+        <a class="wb-sl" href="#wb-info">Skip to "About government"</a>
+      </li>
+    </ul>
+  </nav>
+  <header>
+    <div id="wb-bnr" class="container">
+      {% include "components/lang-toggle.njk" %}
+      <div class="row">
+        <div class="brand col-xs-5 col-md-4" property="publisher" typeof="GovernmentOrganization">
+          <a href="https://www.canada.ca/en.html" property="url"><img src="/static/assets/GCWeb/assets/sig-blk-en.svg" alt="" property="logo">
+            <span class="wb-inv" property="name">
+              Government of Canada /
+              <span lang="fr">Gouvernement du Canada</span></span></a>
+          <meta property="areaServed" typeof="Country" content="Canada">
+          <link property="logo" href="/static/assets/GCWeb/assets/wmms-blk.svg">
+        </div>
+        <section id="wb-srch" class="col-lg-8 text-right">
+          <h2>Search</h2>
+          <form action="#" method="post" name="cse-search-box" role="search" class="form-inline">
+            <div class="form-group">
+              <label for="wb-srch-q" class="wb-inv">Search Canada.ca</label>
+              <input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Search Canada.ca">
+              <datalist id="wb-srch-q-ac"></datalist>
+            </div>
+            <div class="form-group submit">
+              <button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub">
+                <span class="glyphicon-search glyphicon"></span><span class="wb-inv">Search</span></button>
+            </div>
+          </form>
+        </section>
+      </div>
+    </div>
+    <nav class="gcweb-menu" typeof="SiteNavigationElement">
+      <div class="container">
+        <h2 class="wb-inv">Menu</h2>
+        <button type="button" aria-haspopup="true" aria-expanded="false">
+          <span class="wb-inv">Main
+          </span>Menu
+          <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
+        <ul role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/en/services/jobs.html">Jobs and the workplace</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and citizenship</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://travel.gc.ca/">Travel and tourism</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/en/services/business.html">Business and industry</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/en/services/benefits.html">Benefits</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/en/services/health.html">Health</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/en/services/taxes.html">Taxes</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/en/services/environment.html">Environment and natural resources</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/en/services/defence.html">National security and defence</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/en/services/finance.html">Money and finances</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/en/services/science.html">Science and innovation</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  </header>
+{% else %}
+  <nav>
+    <ul id="wb-tphp">
+      <li class="wb-slc">
+        <a class="wb-sl" href="#wb-cont">Passer au contenu principal</a>
+      </li>
+      <li class="wb-slc">
+        <a class="wb-sl" href="#wb-info">Passer à «&#160;Au sujet du gouvernement&#160;»</a>
+      </li>
+    </ul>
+  </nav>
+  <header>
+    <div id="wb-bnr" class="container">
+      {% include "components/lang-toggle.njk" %}
+      <div class="row">
+        <div class="brand col-xs-5 col-md-4" property="publisher" typeof="GovernmentOrganization">
+          <a href="https://www.canada.ca/fr.html" property="url"><img src="/static/assets/GCWeb/assets/sig-blk-fr.svg" alt="" property="logo">
+            <span class="wb-inv" property="name">
+              Gouvernement du Canada /
+              <span lang="en">Government of Canada</span></span></a>
+          <meta property="areaServed" typeof="Country" content="Canada">
+          <link property="logo" href="/static/assets/GCWeb/assets/wmms-blk.svg">
+        </div>
+        <section id="wb-srch" class="col-lg-8 text-right">
+          <h2>Recherche</h2>
+          <form action="#" method="post" name="cse-search-box" role="search" class="form-inline">
+            <div class="form-group">
+              <label for="wb-srch-q" class="wb-inv">Rechercher dans Canada.ca</label>
+              <input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="Rechercher dans Canada.ca">
+              <datalist id="wb-srch-q-ac"></datalist>
+            </div>
+            <div class="form-group submit">
+              <button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub">
+                <span class="glyphicon-search glyphicon"></span><span class="wb-inv">Recherche</span></button>
+            </div>
+          </form>
+        </section>
+      </div>
+    </div>
+    <nav class="gcweb-menu" typeof="SiteNavigationElement">
+      <div class="container">
+        <h2 class="wb-inv">Menu</h2>
+        <button type="button" aria-haspopup="true" aria-expanded="false">Menu<span class="wb-inv">
+            principal</span>
+          <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
+        <ul role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-fr.html">
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/fr/services/emplois.html">Emplois et milieu de travail</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/fr/services/immigration-citoyennete.html">Immigration et citoyenneté</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://voyage.gc.ca/">Voyage et tourisme</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/fr/services/entreprises.html">Entreprises et industrie</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/fr/services/prestations.html">Prestations</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/fr/services/sante.html">Santé</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/fr/services/impots.html">Impôts</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/fr/services/environnement.html">Environnement et ressources naturelles</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/fr/services/defense.html">Sécurité nationale et défense</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/fr/services/culture.html">Culture, histoire et sport</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/fr/services/police.html">Services de police, justice et urgences</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/fr/services/transport.html">Transport et infrastructure</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://international.gc.ca/world-monde/index.aspx?lang=fra">Canada et le monde</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/fr/services/finance.html">Argent et finances</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" href="https://www.canada.ca/fr/services/science.html">Science et innovation</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  </header>
+{% endif %}

--- a/_includes/layouts/base-wet.njk
+++ b/_includes/layouts/base-wet.njk
@@ -3,48 +3,9 @@
 <!--[if gt IE 8]><!-->
 <html class="no-js" lang="en" dir="ltr">
 		<!--<![endif]-->
-		<head>
-				<meta charset="utf-8">
-				<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-				<title>Canada.ca theme - Canada.ca
-				</title>
-				<meta content="width=device-width,initial-scale=1" name="viewport">
-				<meta name="description" content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
-				<!--[if gte IE 9 | !IE ]><!-->
-				<link href="/static/assets/GCWeb/assets/favicon.ico" rel="icon" type="image/x-icon">
-				<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
-				<link rel="stylesheet" href="/static/assets/GCWeb/css/theme.min.css">
-				<!--<![endif]-->
-				<!--[if lt IE 9]> <link href="/static/assets/GCWeb/assets/favicon.ico" rel="shortcut icon" /> <link rel="stylesheet" href="/static/assets/GCWeb/css/ie8-theme.min.css" /> <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.js"></script> <script src="/static/assets/wet-boew/js/ie8-wet-boew.min.js"></script> <![endif]-->
-				<!--[if lte IE 9]> <![endif]-->
-				<noscript><link rel="stylesheet" href="/static/assets/wet-boew/css/noscript.min.css"/></noscript>
-		</head>
+		{% include "components/head.njk" %}
 		<body vocab="http://schema.org/" typeof="WebPage">
-				<nav>
-						<ul id="wb-tphp">
-								<li class="wb-slc">
-										<a class="wb-sl" href="#wb-cont">Skip to main content</a>
-								</li>
-								<li class="wb-slc">
-										<a class="wb-sl" href="#wb-info">Skip to "About government"</a>
-								</li>
-						</ul>
-				</nav>
-				<header>
-						<div id="wb-bnr" class="container">
-								{% include "components/lang-toggle.njk" %}
-								<div class="row">
-										<div class="brand col-xs-5 col-md-4" property="publisher" typeof="GovernmentOrganization">
-												<a href="https://www.canada.ca/en.html" property="url"><img src="/static/assets/GCWeb/assets/sig-blk-en.svg" alt="" property="logo">
-														<span class="wb-inv" property="name">
-																Government of Canada /
-																<span lang="fr">Gouvernement du Canada</span></span></a>
-												<meta property="areaServed" typeof="Country" content="Canada">
-												<link property="logo" href="/static/assets/GCWeb/assets/wmms-blk.svg">
-										</div>
-								</div>
-						</div>
-				</header>
+				{% include "components/header.njk" %}
 				<main property="mainContentOfPage" class="container" typeof="WebPageElement">
 						{{ layoutContent | safe }}
 
@@ -127,75 +88,7 @@
 								</dl>
 						</div>
 				</main>
-				<footer id="wb-info">
-						<div class="landscape">
-								<nav class="container wb-navcurr">
-										<h2 class="wb-inv">About government</h2>
-										<ul class="list-unstyled colcount-sm-2 colcount-md-3">
-												<li>
-														<a href="https://www.canada.ca/en/contact.html">Contact us</a>
-												</li>
-												<li>
-														<a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a>
-												</li>
-												<li>
-														<a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a>
-												</li>
-												<li>
-														<a href="https://www.canada.ca/en/news.html">News</a>
-												</li>
-												<li>
-														<a href="https://www.canada.ca/en/government/system/laws.html">Treaties, laws and regulations</a>
-												</li>
-												<li>
-														<a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide reporting</a>
-												</li>
-												<li>
-														<a href="https://pm.gc.ca/eng">Prime Minister</a>
-												</li>
-												<li>
-														<a href="https://www.canada.ca/en/government/system.html">How government works</a>
-												</li>
-												<li>
-														<a href="https://open.canada.ca/en/">Open government</a>
-												</li>
-										</ul>
-								</nav>
-						</div>
-						<div class="brand">
-								<div class="container">
-										<div class="row">
-												<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
-														<h2 class="wb-inv">About this site</h2>
-														<ul>
-																<li>
-																		<a href="https://www.canada.ca/en/social.html">Social media</a>
-																</li>
-																<li>
-																		<a href="https://www.canada.ca/en/mobile.html">Mobile applications</a>
-																</li>
-																<li>
-																		<a href="https://www1.canada.ca/en/newsite.html">About Canada.ca</a>
-																</li>
-																<li>
-																		<a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a>
-																</li>
-																<li>
-																		<a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a>
-																</li>
-														</ul>
-												</nav>
-												<div class="col-xs-6 visible-sm visible-xs tofpg">
-														<a href="#wb-cont">Top of Page
-																<span class="glyphicon glyphicon-chevron-up"></span></a>
-												</div>
-												<div class="col-xs-6 col-md-3 col-lg-2 text-right">
-														<img src="/static/assets/GCWeb/assets/wmms-blk.svg" alt="Symbol of the Government of Canada">
-												</div>
-										</div>
-								</div>
-						</div>
-				</footer>
+				{% include "components/footer.njk" %}
 				<!--[if gte IE 9 | !IE ]><!-->
 				<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
 				<script src="/static/assets/wet-boew/js/wet-boew.min.js"></script>


### PR DESCRIPTION
right now we're looking at locale, and serving up html based on the locale
There are more elegant ways of handling this that don't rely on duplicating markup, but for the sake of rapidly pushing this out, this is what we got right now

I also brought the menu and search back