### PR TITLE
Use the CDS github oauth gateway for authentication

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,7 +1,7 @@
 backend:
   name: github
   branch: master # Branch to update (optional; defaults to master)
-  repo: cds-snc/digital-canada-ca
+  repo: cds-snc/c-19-benefits-cms
   base_url: https://f1jj4za18c.execute-api.us-east-1.amazonaws.com
   auth_endpoint: /production/auth
 

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,6 +1,9 @@
 backend:
-  name: git-gateway
+  name: github
   branch: master # Branch to update (optional; defaults to master)
+  repo: cds-snc/digital-canada-ca
+  base_url: https://f1jj4za18c.execute-api.us-east-1.amazonaws.com
+  auth_endpoint: /production/auth
 
 # Uncomment below to enable drafts
 # publish_mode: editorial_workflow


### PR DESCRIPTION
# What this does
Switches auth backend to Github, using the CDS Github Oauth Gateway that the website uses.
