### PR TITLE
Feature/more accurate preview

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,6 +2,9 @@ backend:
   name: git-gateway
   branch: master # Branch to update (optional; defaults to master)
 
+# when using the default proxy server port
+# local_backend: true
+
 # Uncomment below to enable drafts
 # publish_mode: editorial_workflow
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -10,5 +10,6 @@
   <body>
     <!-- Include the script that builds the page and powers Netlify CMS -->
     <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <script type="module" src="/admin/preview-templates/index.js"></script>
   </body>
 </html>

--- a/admin/preview-templates/index.js
+++ b/admin/preview-templates/index.js
@@ -4,16 +4,3 @@ CMS.registerPreviewTemplate("enPages", Page);
 CMS.registerPreviewTemplate("frPages", Page);
 
 CMS.registerPreviewStyle("/static/assets/GCWeb/css/theme.min.css");
-
-// Register any CSS file on the home page as a preview style
-fetch("/en/")
-  .then(response => response.text())
-  .then(html => {
-    const f = document.createElement("html");
-    f.innerHTML = html;
-    Array.from(f.getElementsByTagName("link")).forEach(tag => {
-      if (tag.rel == "stylesheet" && !tag.media) {
-        CMS.registerPreviewStyle(tag.href);
-      }
-    });
-  });

--- a/admin/preview-templates/index.js
+++ b/admin/preview-templates/index.js
@@ -1,0 +1,19 @@
+import Page from "/admin/preview-templates/page.js";
+
+CMS.registerPreviewTemplate("enPages", Page);
+CMS.registerPreviewTemplate("frPages", Page);
+
+CMS.registerPreviewStyle("/static/assets/GCWeb/css/theme.min.css");
+
+// Register any CSS file on the home page as a preview style
+fetch("/en/")
+  .then(response => response.text())
+  .then(html => {
+    const f = document.createElement("html");
+    f.innerHTML = html;
+    Array.from(f.getElementsByTagName("link")).forEach(tag => {
+      if (tag.rel == "stylesheet" && !tag.media) {
+        CMS.registerPreviewStyle(tag.href);
+      }
+    });
+  });

--- a/admin/preview-templates/page.js
+++ b/admin/preview-templates/page.js
@@ -1,0 +1,20 @@
+import htm from "https://unpkg.com/htm?module";
+
+const html = htm.bind(h);
+
+// Preview component for a Page
+const Page = createClass({
+  render() {
+    const entry = this.props.entry;
+
+    return html`
+      <main property="mainContentOfPage" class="container" typeof="WebPageElement">
+        ${this.props.widgetFor("intro")}
+        <span> [PLACE HOLDER - Table of Contents will generate here] </span>
+        ${this.props.widgetFor("body")}
+      </main>
+    `;
+  }
+});
+
+export default Page;


### PR DESCRIPTION
It's not 100% accurate, but a little closer to reality. I'll wait until PR #5 gets merged, to integrate it into here and be sure all is still well.

I couldn't get the plugin for the auto-generated TOC to work in preview, and instead in the template input text that says [Placeholder - table of contents will go here]. I'm sure we could include it with a custom solution, but that would take quite a bit, so I'm leaving it at placeholder for now (but open to suggestions for better place holders, or welcome anyone else wanting to implement the toc)

![image](https://user-images.githubusercontent.com/6607541/77572927-37527a00-6ea6-11ea-9db1-86ec13e05316.png)
