### PR TITLE
Deploy en/fr separately

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -1,8 +1,5 @@
 name: Eleventy Build
-on:
-  push:
-    branches:
-      - master
+on: [push]
 
 jobs:
   build_deploy:
@@ -18,9 +15,21 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
-      - name: Deploy
+      - name: Deploy Bilingual
         uses: bacongobbler/azure-blob-storage-upload@v1.0.0
         with:
           source_dir: _site
           container_name: $web
           connection_string: ${{ secrets.AZ_ConnectionString }}
+      - name: Deploy English
+        uses: bacongobbler/azure-blob-storage-upload@v1.0.0
+        with:
+          source_dir: _site/en
+          container_name: $web
+          connection_string: ${{ secrets.AZ_EN_ConnectionString }}
+      - name: Deploy French
+        uses: bacongobbler/azure-blob-storage-upload@v1.0.0
+        with:
+          source_dir: _site/fr
+          container_name: $web
+          connection_string: ${{ secrets.AZ_FR_ConnectionString }}

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -1,5 +1,8 @@
 name: Eleventy Build
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build_deploy:


### PR DESCRIPTION
# What this does
Splits the deployment - since we'll have two domains (en/fr), we'll publish english and french content in separate storage containers (this is the same setup as the CDS website).

Here are the temporary urls:
EN: https://covidbenefitsen.z9.web.core.windows.net
FR: https://covidbenefitsfr.z9.web.core.windows.net

## What this doesn't do
The language switch is now broken, since it expects to be able to switch between paths (ie, `/en` to `/fr`).